### PR TITLE
Add discovery of force feedback capability of devices and axes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /lib
 /out
 CMakeSettings.json
+/debug.txt

--- a/src/dill.cpp
+++ b/src/dill.cpp
@@ -42,6 +42,21 @@ HANDLE g_joystick_thread = NULL;
 // Flag indicating whether or not device initialization is complete
 std::atomic<bool> g_initialization_done = false;
 
+// Maps axis offsets to axis number (1-indexed).
+// To get axis index in AxisMap, subtract 1.
+static std::unordered_map<DWORD, int> g_axis_id_lookup =
+{
+    {DIJOFS_X, 1},
+    {DIJOFS_Y, 2},
+    {DIJOFS_Z, 3},
+    {DIJOFS_RX, 4},
+    {DIJOFS_RY, 5},
+    {DIJOFS_RZ, 6},
+    {DIJOFS_SLIDER(0), 7},
+    {DIJOFS_SLIDER(1), 8}
+};
+
+
 
 DeviceState::DeviceState()
     :   axis(9, 0)
@@ -163,17 +178,6 @@ void emit_joystick_input_event(DIDEVICEOBJECTDATA const& data, GUID const& guid)
     JoystickInputData evt;
     evt.device_guid = guid;
 
-    static std::unordered_map<DWORD, int> axis_id_lookup =
-    {
-        {FIELD_OFFSET(DIJOYSTATE2, lX), 1},
-        {FIELD_OFFSET(DIJOYSTATE2, lY), 2},
-        {FIELD_OFFSET(DIJOYSTATE2, lZ), 3},
-        {FIELD_OFFSET(DIJOYSTATE2, lRx), 4},
-        {FIELD_OFFSET(DIJOYSTATE2, lRy), 5},
-        {FIELD_OFFSET(DIJOYSTATE2, lRz), 6},
-        {FIELD_OFFSET(DIJOYSTATE2, rglSlider[0]), 7},
-        {FIELD_OFFSET(DIJOYSTATE2, rglSlider[1]), 8}
-    };
     static std::unordered_map<DWORD, int> hat_id_lookup = 
     {
         {FIELD_OFFSET(DIJOYSTATE2, rgdwPOV[0]), 1},
@@ -186,7 +190,7 @@ void emit_joystick_input_event(DIDEVICEOBJECTDATA const& data, GUID const& guid)
     if(data.dwOfs < FIELD_OFFSET(DIJOYSTATE2, rgdwPOV))
     {
         evt.input_type = JoystickInputType::Axis;
-        evt.input_index = axis_id_lookup[data.dwOfs];
+        evt.input_index = g_axis_id_lookup[data.dwOfs];
         evt.value = data.dwData;
         g_data_store.state[guid].axis[evt.input_index] = evt.value;
     }
@@ -507,6 +511,14 @@ BOOL CALLBACK set_axis_range(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef)
     return DIENUM_CONTINUE;
 }
 
+BOOL CALLBACK enumerate_ffb_axes_cb(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef)
+{
+    DeviceSummary* device_summary = reinterpret_cast<DeviceSummary*>(pvRef);
+    int axis_i = g_axis_id_lookup[lpddoi->dwOfs] - 1;
+    device_summary->axis_map[axis_i].ffb_supported = true;
+    return DIENUM_CONTINUE;
+}
+
 void initialize_device(GUID guid, std::string name)
 {
     // Prevent any operations on this device until initialization is done
@@ -633,12 +645,14 @@ void initialize_device(GUID guid, std::string name)
     info.vendor_id = get_vendor_id(device, guid);
     info.product_id = get_product_id(device, guid);
     info.joystick_id = get_joystick_id(device, guid);
+    info.force_feedback = (bool)(capabilities.dwFlags & DIDC_FORCEFEEDBACK);
     strcpy_s(info.name, MAX_PATH, name.c_str());
     info.axis_count = 0;
     for(int i=0; i<8; ++i)
     {
         info.axis_map[i].linear_index = 0;
         info.axis_map[i].axis_index = 0;
+        info.axis_map[i].ffb_supported = false;
     }
 
     auto axis_indices = used_axis_indices(guid);
@@ -726,6 +740,16 @@ void initialize_device(GUID guid, std::string name)
         }
     }
 
+    // Update map of force feedback capable axes.
+    result = device->EnumObjects(enumerate_ffb_axes_cb, &info, DIDFT_AXIS | DIDFT_FFACTUATOR);
+    if (FAILED(result))
+    {
+        logger->error(
+            "{}: Failed to obtain force feedback capable axes, {}",
+            guid_to_string(guid),
+            error_to_string(result)
+        );
+    }
 
     info.button_count = capabilities.dwButtons;
     info.hat_count = capabilities.dwPOVs;

--- a/src/dill.h
+++ b/src/dill.h
@@ -74,12 +74,14 @@ struct JoystickInputData
 /**
  * \brief Stores axis information.
  *
- * Stores the linear and axis index of a single axis.
+ * Stores the linear and axis index of a single axis, and FFB
+ * support (whether the axis has a force feedback actuator).
  */
 struct AxisMap
 {
     DWORD                               linear_index;
     DWORD                               axis_index;
+    bool                                ffb_supported;
 };
 
 /**
@@ -100,6 +102,7 @@ struct DeviceSummary
     DWORD                               button_count;
     DWORD                               hat_count;
     AxisMap                             axis_map[8];
+    bool                                force_feedback;
 };
 
 /**
@@ -225,6 +228,14 @@ BOOL CALLBACK handle_device_cb(LPCDIDEVICEINSTANCE instance, LPVOID data);
  * \brief Fill struct with things
  */
 BOOL CALLBACK set_axis_range(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);
+
+/**
+ * \brief Enumerates axes that have a force feedback actuator.
+ * 
+ * See prototype DIEnumDeviceObjectsCallback. Expects the following dwFlags:
+ * DIDFT_AXIS | DIDFT_FFACTUATOR
+ */
+BOOL CALLBACK enumerate_ffb_axes_cb(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);
 
 /**
  * \brief Enumerates all DirectInput devices present on the system.

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -65,6 +65,13 @@ void device_change_callback(DeviceSummary info, DeviceActionType action)
             info.product_id,
             info.joystick_id
         ) << std::endl;
+		if (info.force_feedback) {
+			for (int i = 0; i < 8; ++i) {
+				if (info.axis_map[i].ffb_supported) {
+					std::cout << "Force feedback supported on axis " << i << std::endl;
+				}
+			}
+		}
     }
 }
 


### PR DESCRIPTION
Add discovery of force feedback capability of devices and axes. Update example to use these new attributes.

The example can be run against a real FFB device, or again a vJoy instance with FFB enabled. It currently always shows 2 FFB axes.

Issue #4 